### PR TITLE
fix(#6): make module vendor-able

### DIFF
--- a/bridge/vendor_fix.go
+++ b/bridge/vendor_fix.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package bridge contains golang to c shim functions.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file vendor_fix.go at the root of the module for more information.
+package bridge

--- a/h/vendor_fix.go
+++ b/h/vendor_fix.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package h contains C heaer files.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file vendor_fix.go at the root of the module for more information.
+package h

--- a/vendor_fix.go
+++ b/vendor_fix.go
@@ -1,0 +1,11 @@
+// +build dummy
+
+// This file is part of a workaround for `go mod vendor` which won't vendor
+// C files if there's no Go file in the same directory.
+// This would prevent the bridge/bridge.c file to be vendored.
+//
+// See this issue for reference: https://github.com/golang/go/issues/26366
+package sqlite
+
+import _ "go.riyazali.net/sqlite/h"
+import _ "go.riyazali.net/sqlite/bridge"


### PR DESCRIPTION
This MR fixes #6 and allow users to use `go mod vendor` to vendor this module