### PR TITLE
Fix examples and their extensions on MacOS

### DIFF
--- a/_examples/Makefile
+++ b/_examples/Makefile
@@ -1,26 +1,18 @@
 # compile all extensions under _examples/
 
+DIRS = $(patsubst %/,%,$(wildcard */))
+EXT = so
+ifeq ($(shell uname),Darwin)
+	EXT = dylib
+endif
+LIBS = $(addsuffix .$(EXT),$(DIRS))
+
 .PHONY: all
-all: compare.so series.so sum.so upper.so subtype.so
+all: $(LIBS)
 
 .PHONY: clean
 clean:
-	-rm -f compare.so series.so sum.so upper.so subtype.so
+	-rm -f $(LIBS)
 
-compare.so:
-	 go build -buildmode=c-shared -o $@ ./compare
-
-series.so:
-	 go build -buildmode=c-shared -o $@ ./series
-
-sum.so:
-	 go build -buildmode=c-shared -o $@ ./sum
-
-upper.so:
-	go build -buildmode=c-shared -o $@ ./upper
-
-csv.so:
-	go build -buildmode=c-shared -o $@ ./csv
-
-subtype.so:
-	go build -buildmode=c-shared -o $@ ./subtype
+%.$(EXT):
+	go build -buildmode=c-shared -o $@ ./$*

--- a/_examples/csv/csv.go
+++ b/_examples/csv/csv.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/csv"
 	"fmt"
-	"go.riyazali.net/sqlite"
 	"io"
 	"os"
 	"strconv"
 	"strings"
+
+	"go.riyazali.net/sqlite"
 )
 
 // CsvModule provides an implementation of an sqlite virtual table for reading CSV files.
@@ -125,7 +126,7 @@ func (c *CsvCursor) Next() error {
 	return sqlite.SQLITE_OK
 }
 
-func (c *CsvCursor) Column(ctx *sqlite.Context, i int) error {
+func (c *CsvCursor) Column(ctx *sqlite.VirtualTableContext, i int) error {
 	if i >= 0 && i < len(c.current) && c.current[i] != "" {
 		ctx.ResultText(c.current[i])
 	}

--- a/_examples/series/series.go
+++ b/_examples/series/series.go
@@ -150,7 +150,7 @@ func (cur *SeriesCursor) Next() error {
 	return nil
 }
 
-func (cur *SeriesCursor) Column(context *sqlite.Context, i int) error {
+func (cur *SeriesCursor) Column(context *sqlite.VirtualTableContext, i int) error {
 	var x int64
 	switch i {
 	case SERIES_COLUMN_START:


### PR DESCRIPTION
- Make dylibs on MacOS and detect examples automatically
- Update csv and series examples to use VirtualTableContext
